### PR TITLE
Agregar un ping generico para CI

### DIFF
--- a/mappings/mapping-ci-ping.json
+++ b/mappings/mapping-ci-ping.json
@@ -1,0 +1,10 @@
+{
+    "request": {
+        "method": "HEAD",
+        "url": "/"
+    },
+    "response": {
+        "status": 200,
+        "statusMessage": "Everything was just fine!"
+    }
+}


### PR DESCRIPTION
Necesario para que el proceso de CI pueda detectar que Wiremock esta corriendo, previo a iniciar los tests de cypress: https://github.com/uqbar-project/eg-cypress-intro/pull/1